### PR TITLE
PHP 8.2 notice - Explicitly declare $cache_key

### DIFF
--- a/src/Updater.php
+++ b/src/Updater.php
@@ -11,7 +11,14 @@ class Updater {
 	 * @var object
 	 */
 	protected $client;
-
+	
+	/**
+	* Holds the cache key for the version info
+	*
+	* @var string
+	*/
+	private $cache_key; // Declared as private
+	
 	/**
 	 * Initialize the class
 	 *


### PR DESCRIPTION
Getting this error on PHP 8.2:

`Creation of dynamic property SureCart\Licensing\Updater::$cache_key is deprecated`

This PR explicitly declare $cache_key in the class.