### PR TITLE
Activation and License data added in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,40 @@ You may set your own textdomain to translate text.
 ```php
 $client->set_textdomain( 'your-project-textdomain' );
 ```
+
+## Get activation object data
+```php
+$client->settings()->get_activation();
+```
+
+**Demo activation response**
+```json
+{
+  "id": "activation-id",
+  "object": "activation",
+  "counted": null,
+  "name": "WebsiteDomain",
+  "fingerprint": "https://example.com",
+  "license": {
+    "id": "license-id",
+    "object": "license",
+    "activations_count": 0,
+    "activation_limit": null,
+    "key": "license-key",
+    "status": "active",
+    "product": {
+      "id": "product-id",
+      "object": "product",
+      "description": "<p>Product Description</p>",
+      "name": "Product Name",
+      "created_at": 1683782487,
+      "updated_at": 1706799044
+    },
+    "current_release": "release-id",
+    "created_at": 1706767739,
+    "updated_at": 1706767739
+  },
+  "created_at": 1706798871,
+  "updated_at": 1706798871
+}
+```

--- a/src/Activation.php
+++ b/src/Activation.php
@@ -14,9 +14,9 @@ class Activation {
 	protected $endpoint = 'v1/public/activations';
 
 	/**
-	 * SureCart\Licensing\Client
+	 * SureCart Licensing Client
 	 *
-	 * @var object
+	 * @var \SureCart\Licensing\Client
 	 */
 	protected $client;
 
@@ -52,7 +52,7 @@ class Activation {
 		// send the activation request.
 		$activation = $this->client->send_request(
 			'POST',
-			trailingslashit( $this->endpoint ),
+			trailingslashit( $this->endpoint ) . '?expand[]=license&expand[]=license.product',
 			array(
 				'activation' => array(
 					'fingerprint' => esc_url_raw( get_site_url() ),
@@ -86,7 +86,7 @@ class Activation {
 	public function get( $id = '' ) {
 		return $this->client->send_request(
 			'GET',
-			trailingslashit( $this->endpoint ) . $id
+			trailingslashit( $this->endpoint ) . $id . '?expand[]=license&expand[]=license.product'
 		);
 	}
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -166,7 +166,7 @@ class Client {
 	/**
 	 * Initialize activation model
 	 *
-	 * @return SureCart\Licensing
+	 * @return \SureCart\Licensing\Activation
 	 */
 	public function activation() {
 		if ( ! class_exists( __NAMESPACE__ . '\Activation' ) ) {
@@ -182,7 +182,7 @@ class Client {
 	/**
 	 * Initialize settings page
 	 *
-	 * @return SureCart\Licensing
+	 * @return \SureCart\Licensing\Settings
 	 */
 	public function settings() {
 		if ( ! class_exists( __NAMESPACE__ . '\Settings' ) ) {

--- a/src/License.php
+++ b/src/License.php
@@ -16,7 +16,7 @@ class License {
 	/**
 	 * SureCart\Licensing\Client
 	 *
-	 * @var object
+	 * @var \SureCart\Licensing\Client
 	 */
 	protected $client;
 
@@ -66,6 +66,7 @@ class License {
 				throw new \Exception( $activation->get_error_message() );
 			}
 			$this->client->settings()->activation_id = $activation->id;
+			$this->client->settings()->activation    = $activation;
 			// validate the release.
 			$this->validate_release();
 		} catch ( \Exception $e ) {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -296,15 +296,12 @@ class Settings {
 	 * @return Object|false
 	 */
 	public function get_activation() {
-		$activation = false;
-		if ( $this->activation_id ) {
-			$activation = $this->client->activation()->get( $this->activation_id );
-			if ( is_wp_error( $activation ) ) {
-				$this->add_error( 'deactivaed', $this->client->__( 'Your license has been deactivated for this site.', 'surecart' ) );
-				$this->clear_options();
-			}
+		if ( is_wp_error( $this->activation ) ) {
+			$this->add_error( 'deactivaed', $this->client->__( 'Your license has been deactivated for this site.', 'surecart' ) );
+			$this->clear_options();
 		}
-		return $activation;
+
+		return $this->activation;
 	}
 
 	/**

--- a/tests/unit/SettingsTest.php
+++ b/tests/unit/SettingsTest.php
@@ -19,9 +19,32 @@ class SettingsTest extends \WP_UnitTestCase {
 
 	public function propertyProvider() {
 		return array(
-			'license id'    => array( 'license_id', 'test_id' ),
-			'license key'   => array( 'license_key', 'test_key' ),
-			'activation id' => array( 'activation_id', 'test_activation_id' ),
+			'license id'        => array( 'license_id', 'test_id' ),
+			'license key'       => array( 'license_key', 'test_key' ),
+			'activation id'     => array( 'activation_id', 'test_activation_id' ),
+			'activation object' => array( 'activation', $this->createActivationObject() ),
 		);
+	}
+
+	private function createActivationObject() {
+		// Create a product object.
+		$product         = new stdClass();
+		$product->id     = 'test_product_id';
+		$product->object = 'product';
+		$product->name   = 'Test Product Name';
+
+		// Create a license object.
+		$license          = new stdClass();
+		$license->id      = 'test_id';
+		$license->object  = 'license';
+		$license->product = $product;
+
+		// Create an activation object.
+		$activation          = new stdClass();
+		$activation->id      = 'test_activation_id';
+		$activation->object  = 'activation';
+		$activation->license = $license;
+
+		return $activation;
 	}
 }


### PR DESCRIPTION
## Description
When we activate a license we are storing the activation ID. We should also store the activation object and the expanded license object so that the plugin developer can show data from these.

We should also allow this to be grabbed through the SDK.

Fixes[SC-3534](https://brainstormforce.atlassian.net/browse/SC-3534)

