### PR TITLE
Add support for plugin banners and icons in release.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,20 @@ Sections will require a `changelog` property with an html string of your changel
   "requires_php": "5.3",
   "sections": {
     "description": "This is my plugin description.",
-    "changelog": "<h4>1.0 –  July 20, 2022</h4><ul><li>Bug fixes.</li><li>Initital release.</li></ul>",
-    "frequently asked questions": "<h4>Question<h4><p>Answer</p>"
+    "changelog": "<h4>1.0 – July 20, 2022</h4><ul><li>Bug fixes.</li><li>Initial release.</li></ul>",
+    "frequently asked questions": "<h4>Question</h4><p>Answer</p>"
+  },
+  "icons": {
+    "1x": "https://example.com/assets/icon-128.png",
+    "2x": "https://example.com/assets/icon-256.png"
+  },
+  "banners": {
+    "low": "https://example.com/assets/banner-772x250.png",
+    "high": "https://example.com/assets/banner-1544x500.png"
   }
 }
+
+
 ```
 
 ### ⚠️ Important

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -141,12 +141,10 @@ class Updater {
 
 		$release = $current_release->release_json;
 
-		// must have a slug.
 		if ( ! isset( $release->slug ) ) {
 			return false;
 		}
 
-		// set the new version.
 		$release->new_version = $release->version;
 
 		if ( empty( $release->last_updated ) ) {
@@ -161,12 +159,17 @@ class Updater {
 			$release->banners = (array) $release->banners;
 		}
 
+		if ( isset( $release->icons ) ) {
+			$release->icons = (array) $release->icons;
+		}
+
 		if ( isset( $release->sections ) ) {
 			$release->sections = (array) $release->sections;
 		}
 
 		return $release;
 	}
+
 
 	/**
 	 * Updates information on the "View version x.x details" page with custom data.


### PR DESCRIPTION
This PR introduces support for banners and icons in plugin / themes metadata by:

Updating the README.md example to include valid icons and banners fields.

Ensuring the icons field is cast to an array in get_project_latest_version() (just like banners and sections) to prevent fatal errors when accessed in WordPress core.

README.md
Fixed an invalid JSON example (missing comma and malformed HTML in frequently asked questions).

**Added:**

icons field with 1x and 2x example URLs.

banners field with low and high example URLs.

src/Updater.php
Cast $release->icons to array if present:

`if ( isset( $release->icons ) ) {
    $release->icons = (array) $release->icons;
}
`
This prevents the fatal error:
Cannot use object of type stdClass as array
in wp-admin/update-core.php when WordPress expects an array.

**Why:**

Without this change, including icons in release.json causes a fatal error during update checks due to WordPress treating it as an array. This fix ensures compatibility with WordPress core update handling and enables visual branding in the plugin list.

This Video explains what it does and shows it in action https://app.usebubbles.com/aRWpKMJSvGc3hLgUcNtfTr/sure-cart-sdk-pull-request

**How to Test**

Add icons and banners to your release.json.
Trigger a plugin update check (wp-admin/update-core.php).

Confirm:
- [ ] No fatal errors occur.
- [ ] Icons and banners display correctly in the WordPress admin UI (if supported).

