### PR TITLE
fix(licence): issue with specific error message in validate_license

### DIFF
--- a/src/License.php
+++ b/src/License.php
@@ -245,7 +245,7 @@ class License {
 	 */
 	public function validate_license( $license ) {
 		if ( is_wp_error( $license ) ) {
-			if ( $license->get_error_code( 'not_found' ) ) {
+			if ( 'not_found' === $license->get_error_code() ) {
 				return new \WP_Error( $license->get_error_code(), $this->client->__( 'This license key is not valid. Please double check it and try again.' ) );
 			}
 			return $license;


### PR DESCRIPTION
WP_Errror::get_error_code() does not take any arguments. This commit fix the issue.